### PR TITLE
Add functionality for freeing Renderables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,9 @@ target_link_libraries(test_Console ${USED_LIBS})
 add_executable(test_StaticMesh src/test_StaticMesh.cpp)
 target_link_libraries(test_StaticMesh ${USED_LIBS})
 
+add_executable(test_AddRemove src/test_AddRemove.cpp)
+target_link_libraries(test_AddRemove ${USED_LIBS})
+
 add_executable(test_SoundSource src/test_SoundSource.cpp)
 target_link_libraries(test_SoundSource ${USED_LIBS})
 

--- a/src/test_AddRemove.cpp
+++ b/src/test_AddRemove.cpp
@@ -57,14 +57,14 @@ void createMesh()
     cubeMesh->setDiffuseTexture(*cubeDiffuseTexture);
     
     worldRenderer->addWorldRenderable(cubeMesh);
-	meshExists = true;
+    meshExists = true;
 }
 
 void deleteMesh()
 {
-	worldRenderer->freeRenderable(cubeMesh);
-	delete cubeMesh; cubeMesh = 0;
-	meshExists = false;
+    worldRenderer->freeRenderable(cubeMesh);
+    delete cubeMesh; cubeMesh = 0;
+    meshExists = false;
 }
 
 void setup()
@@ -77,7 +77,7 @@ void setup()
     worldRenderer->addScreenRenderable(screenEffect, false, false);
 
     cubeDiffuseTexture = new draw::RGBATexture2D(img::Image::createTestImage());
-	createMesh();
+    createMesh();
 }
 
 void cleanup()
@@ -98,13 +98,13 @@ void update(const double &dt)
     //Tell the world renderer that the camera has changed.
     worldRenderer->setCamera(cameraPosition, cameraOrientation);
 
-	currentTime += dt;
-	if( (int(currentTime/flickerTime) % 2) == 0 && !meshExists) createMesh();
-	else if( (int(currentTime/flickerTime) % 2) == 1 && meshExists)
-	{
-		deleteMesh();
-//		for(unsigned int i = 0; i < 20; i++) { createMesh(); deleteMesh(); }
-	}
+    currentTime += dt;
+    if( (int(currentTime/flickerTime) % 2) == 0 && !meshExists) createMesh();
+    else if( (int(currentTime/flickerTime) % 2) == 1 && meshExists)
+    {
+        deleteMesh();
+//        for(unsigned int i = 0; i < 20; i++) { createMesh(); deleteMesh(); }
+    }
 }
 
 void render()

--- a/src/test_AddRemove.cpp
+++ b/src/test_AddRemove.cpp
@@ -47,17 +47,24 @@ vec3 cameraPosition = vec3(0.0f, 0.0f, 3.0f);
 vec4 cameraOrientation = vec4(0.0f, 0.0f, 0.0f, 1.0f);
 
 float currentTime = 0.0f;
-float flickerTime = 0.0f;
+float flickerTime = 0.01f;
 bool meshExists = false;
 
 void createMesh()
 {
     //Create a cube mesh and paint it with a texture.
     cubeMesh = new draw::StaticMesh(mesh::StaticMesh::createCubeMesh(0.5f));
-    cubeDiffuseTexture = new draw::RGBATexture2D(img::Image::createTestImage());
     cubeMesh->setDiffuseTexture(*cubeDiffuseTexture);
     
     worldRenderer->addWorldRenderable(cubeMesh);
+	meshExists = true;
+}
+
+void deleteMesh()
+{
+	worldRenderer->freeRenderable(cubeMesh);
+	delete cubeMesh; cubeMesh = 0;
+	meshExists = false;
 }
 
 void setup()
@@ -69,6 +76,7 @@ void setup()
     worldRenderer = new draw::WorldRenderer(application->getScreenWidth(), application->getScreenHeight());
     worldRenderer->addScreenRenderable(screenEffect, false, false);
 
+    cubeDiffuseTexture = new draw::RGBATexture2D(img::Image::createTestImage());
 	createMesh();
 }
 
@@ -89,6 +97,14 @@ void update(const double &dt)
     
     //Tell the world renderer that the camera has changed.
     worldRenderer->setCamera(cameraPosition, cameraOrientation);
+
+	currentTime += dt;
+	if( (int(currentTime/flickerTime) % 2) == 0 && !meshExists) createMesh();
+	else if( (int(currentTime/flickerTime) % 2) == 1 && meshExists)
+	{
+		deleteMesh();
+//		for(unsigned int i = 0; i < 20; i++) { createMesh(); deleteMesh(); }
+	}
 }
 
 void render()

--- a/src/test_AddRemove.cpp
+++ b/src/test_AddRemove.cpp
@@ -1,0 +1,127 @@
+/*
+Copyright 2012-2015, Bas Fagginger Auer and Matthijs van Dorp.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <exception>
+
+#include <config.h>
+
+#include <tiny/os/application.h>
+#include <tiny/os/sdlapplication.h>
+
+#include <tiny/img/image.h>
+#include <tiny/mesh/staticmesh.h>
+
+#include <tiny/draw/staticmesh.h>
+#include <tiny/draw/effects/diffuse.h>
+#include <tiny/draw/worldrenderer.h>
+
+using namespace std;
+using namespace tiny;
+
+os::Application *application = 0;
+
+draw::WorldRenderer *worldRenderer = 0;
+
+draw::StaticMesh *cubeMesh = 0;
+draw::RGBATexture2D *cubeDiffuseTexture = 0;
+
+draw::Renderable *screenEffect = 0;
+
+vec3 cameraPosition = vec3(0.0f, 0.0f, 3.0f);
+vec4 cameraOrientation = vec4(0.0f, 0.0f, 0.0f, 1.0f);
+
+float currentTime = 0.0f;
+float flickerTime = 0.0f;
+bool meshExists = false;
+
+void createMesh()
+{
+    //Create a cube mesh and paint it with a texture.
+    cubeMesh = new draw::StaticMesh(mesh::StaticMesh::createCubeMesh(0.5f));
+    cubeDiffuseTexture = new draw::RGBATexture2D(img::Image::createTestImage());
+    cubeMesh->setDiffuseTexture(*cubeDiffuseTexture);
+    
+    worldRenderer->addWorldRenderable(cubeMesh);
+}
+
+void setup()
+{
+    //Render only diffuse colours to the screen.
+    screenEffect = new draw::effects::Diffuse();
+    
+    //Create a renderer and add the cube and the diffuse rendering effect to it.
+    worldRenderer = new draw::WorldRenderer(application->getScreenWidth(), application->getScreenHeight());
+    worldRenderer->addScreenRenderable(screenEffect, false, false);
+
+	createMesh();
+}
+
+void cleanup()
+{
+    delete worldRenderer;
+    
+    delete screenEffect;
+    
+    delete cubeMesh;
+    delete cubeDiffuseTexture;
+}
+
+void update(const double &dt)
+{
+    //Move the camera around.
+    application->updateSimpleCamera(dt, cameraPosition, cameraOrientation);
+    
+    //Tell the world renderer that the camera has changed.
+    worldRenderer->setCamera(cameraPosition, cameraOrientation);
+}
+
+void render()
+{
+    worldRenderer->clearTargets();
+    worldRenderer->render();
+}
+
+int main(int, char **)
+{
+    try
+    {
+        application = new os::SDLApplication(SCREEN_WIDTH, SCREEN_HEIGHT);
+        setup();
+    }
+    catch (std::exception &e)
+    {
+        cerr << "Unable to start application!" << endl;
+        return -1;
+    }
+    
+    while (application->isRunning())
+    {
+        update(application->pollEvents());
+        render();
+        application->paint();
+    }
+    
+    cleanup();
+    delete application;
+    
+    cerr << "Goodbye." << endl;
+    
+    return 0;
+}
+

--- a/tiny/draw/renderer.cpp
+++ b/tiny/draw/renderer.cpp
@@ -219,10 +219,18 @@ void Renderer::addRenderable(Renderable *renderable, const bool &readFromDepthTe
         }
 #endif
         
-        j = shaderPrograms.insert(shaderPrograms.begin(), std::pair<unsigned int, detail::BoundProgram *>(shaderProgram->hash, shaderProgram));
+        j = shaderPrograms.insert( std::pair<unsigned int, detail::BoundProgram *>(shaderProgram->hash, shaderProgram)).first;
     }
+	else delete shaderProgram;
     
     renderables.push_back(detail::BoundRenderable(renderable, j->first, readFromDepthTexture, writeToDepthTexture, blendMode));
+}
+
+bool Renderer::freeRenderable(Renderable * renderable)
+{
+    assert(renderable);
+
+	return true;
 }
 
 void Renderer::addRenderTarget(const std::string &name)

--- a/tiny/draw/renderer.cpp
+++ b/tiny/draw/renderer.cpp
@@ -130,14 +130,14 @@ bool detail::BoundProgram::validate() const
 void detail::BoundProgram::addRenderable(Renderable * renderable)
 {
 #ifndef NDEBUG
-	assert(renderables.count(renderable) == 0);
+    assert(renderables.count(renderable) == 0);
 #endif
-	renderables.insert(renderable);
+    renderables.insert(renderable);
 }
 
 void detail::BoundProgram::freeRenderable(Renderable * renderable)
 {
-	assert(renderables.erase(renderable));
+    assert(renderables.erase(renderable));
 }
 
 Renderer::Renderer() :
@@ -239,31 +239,31 @@ void Renderer::addRenderable(Renderable *renderable, const bool &readFromDepthTe
         delete shaderProgram;
     }
     
-	j->second->addRenderable(renderable);
+    j->second->addRenderable(renderable);
     renderables.insert(detail::BoundRenderable(renderable, j->first, readFromDepthTexture, writeToDepthTexture, blendMode));
 }
 
 bool Renderer::freeRenderable(Renderable * renderable)
 {
-	detail::BoundRenderable dummy(renderable, 0, 0, 0, BlendReplace);
-	std::set<detail::BoundRenderable>::iterator k = renderables.find(dummy);
-	if(renderable == 0 || k == renderables.end()) return false;
-	unsigned int boundProgHash = k->shaderProgramHash;
-	std::map<unsigned int, detail::BoundProgram *>::iterator j = shaderPrograms.find(boundProgHash);
+    detail::BoundRenderable dummy(renderable, 0, 0, 0, BlendReplace);
+    std::set<detail::BoundRenderable>::iterator k = renderables.find(dummy);
+    if(renderable == 0 || k == renderables.end()) return false;
+    unsigned int boundProgHash = k->shaderProgramHash;
+    std::map<unsigned int, detail::BoundProgram *>::iterator j = shaderPrograms.find(boundProgHash);
 #ifndef NDEBUG
-	assert(j != shaderPrograms.end());
+    assert(j != shaderPrograms.end());
 #endif
-	j->second->freeRenderable(renderable);
-	renderables.erase(k);
-	if(j->second->numRenderables() == 0)
-	{
-		delete j->second;
-		shaderPrograms.erase(j);
-	}
+    j->second->freeRenderable(renderable);
+    renderables.erase(k);
+    if(j->second->numRenderables() == 0)
+    {
+        delete j->second;
+        shaderPrograms.erase(j);
+    }
 
-	std::cout << " Freed renderable, there are "<<shaderPrograms.size()<<" programs and "<<renderables.size()<<" renderables. "<<std::endl;
+    std::cout << " Freed renderable, there are "<<shaderPrograms.size()<<" programs and "<<renderables.size()<<" renderables. "<<std::endl;
 
-	return true;
+    return true;
 }
 
 void Renderer::addRenderTarget(const std::string &name)

--- a/tiny/draw/renderer.cpp
+++ b/tiny/draw/renderer.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright 2012, Bas Fagginger Auer.
+Copyright 2012-2015, Bas Fagginger Auer and Matthijs van Dorp.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -127,6 +127,19 @@ bool detail::BoundProgram::validate() const
     return false;
 }
 
+void detail::BoundProgram::addRenderable(Renderable * renderable)
+{
+#ifndef NDEBUG
+	assert(renderables.count(renderable) == 0);
+#endif
+	renderables.insert(renderable);
+}
+
+void detail::BoundProgram::freeRenderable(Renderable * renderable)
+{
+	assert(renderables.erase(renderable));
+}
+
 Renderer::Renderer() :
     frameBufferIndex(0),
     renderTargetNames(),
@@ -219,16 +232,33 @@ void Renderer::addRenderable(Renderable *renderable, const bool &readFromDepthTe
         }
 #endif
         
-        j = shaderPrograms.insert( std::pair<unsigned int, detail::BoundProgram *>(shaderProgram->hash, shaderProgram)).first;
+        j = shaderPrograms.insert( std::make_pair(shaderProgram->hash, shaderProgram)).first;
     }
 	else delete shaderProgram;
     
-    renderables.push_back(detail::BoundRenderable(renderable, j->first, readFromDepthTexture, writeToDepthTexture, blendMode));
+	j->second->addRenderable(renderable);
+    renderables.insert(detail::BoundRenderable(renderable, j->first, readFromDepthTexture, writeToDepthTexture, blendMode));
 }
 
 bool Renderer::freeRenderable(Renderable * renderable)
 {
-    assert(renderable);
+	detail::BoundRenderable dummy(renderable, 0, 0, 0, BlendReplace);
+	std::set<detail::BoundRenderable>::iterator k = renderables.find(dummy);
+	if(renderable == 0 || k == renderables.end()) return false;
+	unsigned int boundProgHash = k->shaderProgramHash;
+	std::map<unsigned int, detail::BoundProgram *>::iterator j = shaderPrograms.find(boundProgHash);
+#ifndef NDEBUG
+	assert(j != shaderPrograms.end());
+#endif
+	j->second->freeRenderable(renderable);
+	renderables.erase(k);
+	if(j->second->numRenderables() == 0)
+	{
+		delete j->second;
+		shaderPrograms.erase(j);
+	}
+
+	std::cout << " Freed renderable, there are "<<shaderPrograms.size()<<" programs and "<<renderables.size()<<" renderables. "<<std::endl;
 
 	return true;
 }
@@ -313,7 +343,7 @@ void Renderer::render() const
     
     uniformMap.bindTextures();
     
-    for (std::list<detail::BoundRenderable>::const_iterator i = renderables.begin(); i != renderables.end(); ++i)
+    for (std::set<detail::BoundRenderable>::const_iterator i = renderables.begin(); i != renderables.end(); ++i)
     {
         if (i->readFromDepthTexture) GL_CHECK(glEnable(GL_DEPTH_TEST));
         else GL_CHECK(glDisable(GL_DEPTH_TEST));

--- a/tiny/draw/renderer.h
+++ b/tiny/draw/renderer.h
@@ -110,6 +110,8 @@ class Renderer
         virtual ~Renderer();
         
         void addRenderable(Renderable *, const bool & = true, const bool & = true, const BlendMode & = BlendReplace);
+
+		bool freeRenderable(Renderable *);
         
         void setDepthTextureTarget(const DepthTexture2D &texture)
         {

--- a/tiny/draw/renderer.h
+++ b/tiny/draw/renderer.h
@@ -1,5 +1,5 @@
 /*
-Copyright 2012, Bas Fagginger Auer.
+Copyright 2012-2015, Bas Fagginger Auer and Matthijs van Dorp.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <vector>
 #include <list>
 #include <map>
+#include <set>
 
 #include <cassert>
 
@@ -65,6 +66,9 @@ class BoundProgram
         
         const unsigned int hash;
         
+		void addRenderable(Renderable * renderable);
+		void freeRenderable(Renderable * renderable);
+		unsigned int numRenderables(void) const { return renderables.size(); }
     private:
         VertexShader *vertexShader;
         GeometryShader *geometryShader;
@@ -74,6 +78,8 @@ class BoundProgram
         const std::string vertexShaderCode;
         const std::string geometryShaderCode;
         const std::string fragmentShaderCode;
+
+		std::set<Renderable*> renderables;
 };
 
 struct BoundRenderable
@@ -97,6 +103,8 @@ struct BoundRenderable
     bool readFromDepthTexture;
     bool writeToDepthTexture;
     BlendMode blendMode;
+
+	bool operator< (const BoundRenderable &other) const { return renderable < other.renderable; }
 };
 
 }
@@ -164,7 +172,7 @@ class Renderer
         //This class should not be copied.
         Renderer(const Renderer &renderer);
         
-        std::list<detail::BoundRenderable> renderables;
+        std::set<detail::BoundRenderable> renderables;
         std::map<unsigned int, detail::BoundProgram *> shaderPrograms;
         GLuint frameBufferIndex;
         std::vector<std::string> renderTargetNames;

--- a/tiny/draw/renderer.h
+++ b/tiny/draw/renderer.h
@@ -66,9 +66,9 @@ class BoundProgram
         
         const unsigned int hash;
         
-		void addRenderable(Renderable * renderable);
-		void freeRenderable(Renderable * renderable);
-		unsigned int numRenderables(void) const { return renderables.size(); }
+        void addRenderable(Renderable * renderable);
+        void freeRenderable(Renderable * renderable);
+        unsigned int numRenderables(void) const { return renderables.size(); }
     private:
         VertexShader *vertexShader;
         GeometryShader *geometryShader;
@@ -79,7 +79,7 @@ class BoundProgram
         const std::string geometryShaderCode;
         const std::string fragmentShaderCode;
 
-		std::set<Renderable*> renderables;
+        std::set<Renderable*> renderables;
 };
 
 struct BoundRenderable
@@ -104,7 +104,7 @@ struct BoundRenderable
     bool writeToDepthTexture;
     BlendMode blendMode;
 
-	bool operator< (const BoundRenderable &other) const { return renderable < other.renderable; }
+    bool operator< (const BoundRenderable &other) const { return renderable < other.renderable; }
 };
 
 }
@@ -119,7 +119,7 @@ class Renderer
         
         void addRenderable(Renderable *, const bool & = true, const bool & = true, const BlendMode & = BlendReplace);
 
-		bool freeRenderable(Renderable *);
+        bool freeRenderable(Renderable *);
         
         void setDepthTextureTarget(const DepthTexture2D &texture)
         {

--- a/tiny/draw/worldrenderer.cpp
+++ b/tiny/draw/worldrenderer.cpp
@@ -70,7 +70,7 @@ void WorldRenderer::addScreenRenderable(Renderable *renderable, const bool &read
 void WorldRenderer::freeRenderable(Renderable *renderable)
 {
     if(!worldToScreenRenderer.freeRenderable(renderable) && !screenToColourRenderer.freeRenderable(renderable))
-		std::cerr << " WorldRenderer::freeRenderable() : Unable to free a renderable! "<<std::endl;
+        std::cerr << " WorldRenderer::freeRenderable() : Unable to free a renderable! "<<std::endl;
 }
 
 void WorldRenderer::clearTargets() const

--- a/tiny/draw/worldrenderer.cpp
+++ b/tiny/draw/worldrenderer.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright 2012, Bas Fagginger Auer.
+Copyright 2012-2015, Bas Fagginger Auer and Matthijs van Dorp.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tiny/draw/worldrenderer.cpp
+++ b/tiny/draw/worldrenderer.cpp
@@ -67,6 +67,12 @@ void WorldRenderer::addScreenRenderable(Renderable *renderable, const bool &read
     screenToColourRenderer.addRenderable(renderable, readFromDepthTexture, writeToDepthTexture, blendMode);
 }
 
+void WorldRenderer::freeRenderable(Renderable *renderable)
+{
+    if(!worldToScreenRenderer.freeRenderable(renderable) && !screenToColourRenderer.freeRenderable(renderable))
+		std::cerr << " WorldRenderer::freeRenderable() : Unable to free a renderable! "<<std::endl;
+}
+
 void WorldRenderer::clearTargets() const
 {
     worldToScreenRenderer.clearTargets();

--- a/tiny/draw/worldrenderer.h
+++ b/tiny/draw/worldrenderer.h
@@ -45,7 +45,7 @@ class WorldRenderer
         void addWorldRenderable(Renderable *, const bool & = true, const bool & = true, const BlendMode & = BlendReplace);
         void addScreenRenderable(Renderable *, const bool & = true, const bool & = true, const BlendMode & = BlendReplace);
 
-		void freeRenderable(Renderable *);
+        void freeRenderable(Renderable *);
         
         void clearTargets() const;
         void render() const;

--- a/tiny/draw/worldrenderer.h
+++ b/tiny/draw/worldrenderer.h
@@ -44,6 +44,8 @@ class WorldRenderer
         
         void addWorldRenderable(Renderable *, const bool & = true, const bool & = true, const BlendMode & = BlendReplace);
         void addScreenRenderable(Renderable *, const bool & = true, const bool & = true, const BlendMode & = BlendReplace);
+
+		void freeRenderable(Renderable *);
         
         void clearTargets() const;
         void render() const;

--- a/tiny/draw/worldrenderer.h
+++ b/tiny/draw/worldrenderer.h
@@ -1,5 +1,5 @@
 /*
-Copyright 2012, Bas Fagginger Auer.
+Copyright 2012-2015, Bas Fagginger Auer and Matthijs van Dorp.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
That wasn't as hard as I expected.

But that's mostly a tribute to the nice engine. This is my pull request to
fix #5 . Essentially I only added a few dozen lines of code. Here's the
changes and additions included in the last commit of the pull request:

CORE CHANGES

I added a freeRenderable() function to the WorldRenderer. This in turn
calls freeRenderable of each Renderer, which frees all resources.

For doing this efficiently, I changed the Renderer's std::list of
BoundRenderables to an std::set. This allows logarithmic complexity
lookup (instead of linear complexity), which is important for deletion.
For traversal it shouldn't make a difference.

For the std::set to work, I added an operator< to the BoundRenderable
which works by comparing the Renderable\* inside it. This enables another
wonderful construction, namely lookup of a BoundRenderable by creating a
dummy BoundRenderable based on the same Renderable*. This is used by
freeRenderable() to find the BoundRenderable to be deleted.

I also added shader program resource management by including a list of
Renderable*'s in each BoundProgram. Once no more Renderables exist using
the specific program, the program is deleted.

OTHER CHANGES

There was a memory leak in Renderer::addRenderable() because the new
Program wasn't deleted even if it wasn't used, this was fixed in an earlier
commit also part of this pull request.

REMARKS

In issue #5 I also mention textures, but once a texture is no longer used by any of the Renderables I don't think there is any reason why a simple "delete texture" would be unsafe. Therefore #5 can be considered fixed by this pull request.

I checked the memory usage of the program and noticed fluctuations of a few MB. However there was no noticeable uptrend even after I did thousands of create-delete operations. I verified with Valgrind that no memory is lost (at least not in this part of the code).
