### PR TITLE
Move function bodies of TextBox class to .cpp

### DIFF
--- a/tiny/CMakeLists.txt
+++ b/tiny/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(tinygame
             draw/animatedmeshhorde.cpp
             draw/icontexture2d.cpp
             draw/iconhorde.cpp
+            draw/textbox.cpp
             draw/lighthorde.cpp
             draw/terrain.cpp
             draw/effects/diffuse.cpp

--- a/tiny/draw/iconhorde.cpp
+++ b/tiny/draw/iconhorde.cpp
@@ -177,6 +177,13 @@ void ScreenIconHorde::appendText(vec4 & pos, const float &size, const float &asp
     icons.sendToDevice();
 }
 
+void ScreenIconHorde::eraseText(void)
+{
+    nrIcons = 0;
+    for(size_t i = 0; i < maxNrIcons; i++) icons[i] = ScreenIconInstance();
+    icons.sendToDevice();
+}
+
 void ScreenIconHorde::setText(const float &x, const float &y, const float &size, const float &aspectRatio, const std::string &text, const IconTexture2D &map)
 {
     std::cout << " setText() : text="<<text<<" map="<<&map<<" size="<<size<<std::endl;

--- a/tiny/draw/iconhorde.h
+++ b/tiny/draw/iconhorde.h
@@ -90,6 +90,9 @@ class ScreenIconHorde : public Renderable
         /** Append text by adding text starting at a given position. This function
           * adjusts the position given such that additional text can be appended. */
         void appendText(vec4 &, const float &, const float &, const std::string &, const IconTexture2D &, const Colour &, const vec4 &);
+
+        /** Erase the text currently in the ScreenIconHorde object. */
+        void eraseText(void);
         
         void setText(const float &, const float &, const float &, const float &, const std::string &, const IconTexture2D &);
 

--- a/tiny/draw/textbox.cpp
+++ b/tiny/draw/textbox.cpp
@@ -67,6 +67,13 @@ Renderable * TextBox::reserve(Renderable * &currentRenderable)
     else return 0;
 }
 
+void TextBox::setFontTexture(IconTexture2D * _iconMap);
+{
+    iconMap = _iconMap;
+    iconHorde->setIconTexture(*iconMap);
+    setText();
+}
+
 void TextBox::setBoxDimensions(const float &_x, const float &_y, const float &_p, const float &_q)
 {
     box = vec4(_x,_y,_p,_q);

--- a/tiny/draw/textbox.cpp
+++ b/tiny/draw/textbox.cpp
@@ -1,0 +1,88 @@
+/*
+Copyright 2015, Matthijs van Dorp.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tiny/draw/textbox.h>
+
+using namespace tiny;
+using namespace tiny::draw;
+
+size_t TextBox::length(void) const
+{
+    size_t l = 0;
+    for(unsigned int i = 0; i < textFragments.size(); i++)
+        l += textFragments[i].text.length();
+    return l;
+}
+
+
+TextBox::TextBox(IconTexture2D * _iconMap, const float &_size, const float &_aspectRatio) :
+    iconHorde(0), size(_size), aspectRatio(_aspectRatio), box(-1.0f,1.0f,1.0f,-1.0f), iconMap(_iconMap)
+{
+    iconHorde = new ScreenIconHorde( 1 );
+    iconHorde->setIconTexture(*iconMap);
+}
+
+TextBox::~TextBox(void)
+{
+    if(iconHorde)
+    {
+        delete iconHorde;
+        iconHorde = 0;
+    }
+}
+
+void TextBox::addTextFragment(std::string _text, Colour _colour)
+{
+    textFragments.push_back(TextFragment(_text, _colour));
+}
+
+Renderable * TextBox::reserve(Renderable * &currentRenderable)
+{
+    if(!iconHorde || iconHorde->maxNumIcons() <= length())
+    {
+        std::cout << " setText() : Reset iconHorde "<<iconHorde<<" to length "<<length()<<"... "<<std::endl;
+        if(iconHorde)
+        {
+            currentRenderable = iconHorde;
+            delete iconHorde;
+        }
+        iconHorde = new ScreenIconHorde( (unsigned int)(1+length()*1.2) );
+        iconHorde->setIconTexture(*iconMap);
+        return iconHorde;
+    }
+    else return 0;
+}
+
+void TextBox::setBoxDimensions(const float &_x, const float &_y, const float &_p, const float &_q)
+{
+    box = vec4(_x,_y,_p,_q);
+}
+
+void TextBox::setText(void)
+{
+    iconHorde->eraseText();
+    vec4 iconPos(box.x, box.y-size, 0.0f, 0.0f);
+    for(unsigned int i = 0; i < textFragments.size(); i++)
+    {
+        iconHorde->appendText(iconPos, size, aspectRatio, textFragments[i].text, *iconMap, textFragments[i].colour, box);
+    }
+}
+
+Renderable * TextBox::getRenderable(void)
+{
+    return iconHorde;
+}

--- a/tiny/draw/textbox.h
+++ b/tiny/draw/textbox.h
@@ -63,7 +63,7 @@ namespace draw
 
             /** Reset the font texture. Since different fonts have different widths, we also
               * need to re-set the text. */
-            void setFontTexture(IconTexture2D * _iconMap) { iconMap = _iconMap; iconHorde->setIconTexture(*iconMap); setText(); }
+            void setFontTexture(IconTexture2D * _iconMap);
 
             /** Set the maximal dimensions of the box, forbidding rendering of text outside of
               * the square with upper-left corner (_x,_y) and lower-right corner (_p,_q), using

--- a/tiny/draw/textbox.h
+++ b/tiny/draw/textbox.h
@@ -18,8 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <tiny/math/vec.h>
 #include <tiny/draw/renderable.h>
-#include <tiny/draw/vertexbuffer.h>
-#include <tiny/draw/vertexbufferinterpreter.h>
 #include <tiny/draw/icontexture2d.h>
 #include <tiny/draw/iconhorde.h>
 #include <tiny/draw/colour.h>
@@ -52,30 +50,16 @@ namespace draw
 
             std::vector<TextFragment> textFragments;
 
-            size_t length(void) const
-            {
-                size_t l = 0;
-                for(unsigned int i = 0; i < textFragments.size(); i++)
-                    l += textFragments[i].text.length();
-                return l;
-            }
+            size_t length(void) const;
         public:
-            TextBox(IconTexture2D * _iconMap, const float &_size = 0.2f, const float &_aspectRatio = 1.0f) :
-                iconHorde(0), size(_size), aspectRatio(_aspectRatio), box(-1.0f,1.0f,1.0f,-1.0f), iconMap(_iconMap)
-            {
-                iconHorde = new ScreenIconHorde( 1 );
-                iconHorde->setIconTexture(*iconMap);
-            }
+            TextBox(IconTexture2D * _iconMap, const float &_size = 0.2f, const float &_aspectRatio = 1.0f);
 
-            ~TextBox(void)
-            {
-                if(iconHorde) { delete iconHorde; iconHorde = 0; }
-            }
+            ~TextBox(void);
 
-            void addTextFragment(std::string _text, Colour _colour)
-            {
-                textFragments.push_back(TextFragment(_text, _colour));
-            }
+            /** Add a text fragment (a text string plus it colour) to be appended to currently
+              * existing text for the TextBox. Note that text fragments are not rendered until
+              * after TextBox::setText() is called. */
+            void addTextFragment(std::string _text, Colour _colour);
 
             /** Reset the font texture. Since different fonts have different widths, we also
               * need to re-set the text. */
@@ -85,46 +69,17 @@ namespace draw
               * the square with upper-left corner (_x,_y) and lower-right corner (_p,_q), using
               * screen coordinates where (-1,1) is the upper right of the screen and (1,-1) is
               * the lower right. */
-            void setBoxDimensions(const float &_x, const float &_y, const float &_p, const float &_q)
-            {
-                box = vec4(_x,_y,_p,_q);
-            }
+            void setBoxDimensions(const float &_x, const float &_y, const float &_p, const float &_q);
 
             /** Reserve enough space such that the text can be rendered fully. */
-            Renderable * reserve(Renderable * &currentRenderable)
-            {
-                if(!iconHorde || iconHorde->maxNumIcons() <= length())
-                {
-                    std::cout << " setText() : Reset iconHorde "<<iconHorde<<" to length "<<length()<<"... "<<std::endl;
-                    if(iconHorde)
-                    {
-                        currentRenderable = iconHorde;
-                        delete iconHorde;
-                    }
-                    iconHorde = new ScreenIconHorde( (unsigned int)(1+length()*1.2) );
-                    iconHorde->setIconTexture(*iconMap);
-                    return iconHorde;
-                }
-                else return 0;
-            }
+            Renderable * reserve(Renderable * &currentRenderable);
 
             /** Set this Text to appear to the top-right of the location
               * specified by screen coordinates (_x,_y), where both coordinates
               * can vary from -1 to +1. */
-            void setText(void)
-            {
-                vec4 iconPos(box.x, box.y-size, 0.0f, 0.0f);
-                for(unsigned int i = 0; i < textFragments.size(); i++)
-                {
-                    iconHorde->appendText(iconPos, size, aspectRatio, textFragments[i].text, *iconMap, textFragments[i].colour, box);
-                }
-//                iconHorde->setText(-1.0f,-1.0f,0.2,aspectRatio,"Test",*iconMap);
-            }
+            void setText(void);
 
-            Renderable * getRenderable(void)
-            {
-                return iconHorde;
-            }
+            Renderable * getRenderable(void);
     };
 } // end namespace draw
 


### PR DESCRIPTION
As requested in the initial pull request #7, I moved all function code to a source file, except for empty functions (which probably should not delay the compiler) and the functions of /tiny/draw/colour.hpp (which are extremely simple and not really worth making yet another .cpp). This is expected to help making compilation faster.

Also, I made a slight functional adjustment through adding a ScreenIconHorde::eraseText() function to erase the current contents of the ScreenIconHorde. This should allow cleaning up its contents, which could be useful in the case that the text to be displayed changes to something with fewer characters than the initial text string.
