### PR TITLE
Allow new lines and fix bug due to wrapping at a space character

### DIFF
--- a/src/test_Font.cpp
+++ b/src/test_Font.cpp
@@ -50,10 +50,14 @@ void setup()
     
     //Create a drawable textbox object as a collection of instanced screen icons.
     text = new draw::TextBox(fontTexture,0.2,aspectRatio);
-    text->setBoxDimensions(-1.0f,0.0f,0.0f,-1.0f);
+    text->setBoxDimensions(-1.0f,0.0f,0.5f,-1.0f);
     std::string str("A boxed font rendering example for the tiny-game-engine.");
     for(unsigned int i = 0; i < str.size(); i++)
         text->addTextFragment(str.substr(i,1), draw::Colour(255-(i*255)/str.size(),(i*255)/str.size(),0));
+    text->addNewline();
+    str = "Automatic word wrapping, custom colouring and new lines are possible.";
+    for(unsigned int i = 0; i < str.size(); i++)
+        text->addTextFragment(str.substr(i,1), draw::Colour(0,255-(i*255)/str.size(),(i*255)/str.size()));
     
     //Create a renderer and add the textbox to it, disabling depth reading and writing.
     renderer = new draw::Renderer();

--- a/tiny/draw/iconhorde.cpp
+++ b/tiny/draw/iconhorde.cpp
@@ -160,6 +160,7 @@ void ScreenIconHorde::appendText(vec4 & pos, const float &size, const float &asp
                 {
                     float shift = icons[j+1].positionAndSize.x - boxSize.x;
                     float newStart = icons[nrIcons-1].positionAndSize.x - icons[j+1].positionAndSize.x+pos.z;
+                    if(j+1 == nrIcons) newStart = 0.0f; // if space exceeds box, we can start new line at margin
                     for(unsigned int k = j+1; k < nrIcons; k++)
                     {
                         icons[k].positionAndSize.x -= shift;
@@ -186,7 +187,6 @@ void ScreenIconHorde::eraseText(void)
 
 void ScreenIconHorde::setText(const float &x, const float &y, const float &size, const float &aspectRatio, const std::string &text, const IconTexture2D &map)
 {
-    std::cout << " setText() : text="<<text<<" map="<<&map<<" size="<<size<<std::endl;
     //Draw font.
     const float sizeScale = size/map.getMaxIconDimensions().y;
     vec4 pos = vec4(x, y, 0.0f, 0.0f);

--- a/tiny/draw/textbox.cpp
+++ b/tiny/draw/textbox.cpp
@@ -98,6 +98,12 @@ void TextBox::setText(void)
     }
 }
 
+void TextBox::clear(void)
+{
+    textFragments.clear();
+    iconHorde->eraseText();
+}
+
 Renderable * TextBox::getRenderable(void)
 {
     return iconHorde;

--- a/tiny/draw/textbox.cpp
+++ b/tiny/draw/textbox.cpp
@@ -50,11 +50,15 @@ void TextBox::addTextFragment(std::string _text, Colour _colour)
     textFragments.push_back(TextFragment(_text, _colour));
 }
 
+void TextBox::addNewline(void)
+{
+    textFragments.push_back(TextFragment("",Colour(0,0,0)));
+}
+
 Renderable * TextBox::reserve(Renderable * &currentRenderable)
 {
     if(!iconHorde || iconHorde->maxNumIcons() <= length())
     {
-        std::cout << " setText() : Reset iconHorde "<<iconHorde<<" to length "<<length()<<"... "<<std::endl;
         if(iconHorde)
         {
             currentRenderable = iconHorde;
@@ -85,7 +89,12 @@ void TextBox::setText(void)
     vec4 iconPos(box.x, box.y-size, 0.0f, 0.0f);
     for(unsigned int i = 0; i < textFragments.size(); i++)
     {
-        iconHorde->appendText(iconPos, size, aspectRatio, textFragments[i].text, *iconMap, textFragments[i].colour, box);
+        if(textFragments[i].text.length() == 0)
+        {
+            iconPos.x = box.x;
+            iconPos.y -= size;
+        }
+        else iconHorde->appendText(iconPos, size, aspectRatio, textFragments[i].text, *iconMap, textFragments[i].colour, box);
     }
 }
 

--- a/tiny/draw/textbox.h
+++ b/tiny/draw/textbox.h
@@ -43,11 +43,13 @@ namespace draw
             };
 
             ScreenIconHorde * iconHorde;
-            float size; /**< The font size. */
+            float size; /**< The (vertical) font size (note that the screen bottom is at -1 and the top is at +1). */
             float aspectRatio; /**< The aspect ratio used for the font. */
             vec4 box; /**< The width of the text box. */
             IconTexture2D * iconMap; /**< The font map. */
 
+            /** The list of all text fragments of the Text box. New lines are
+              * started by inserting a text fragment with an empty text string. */
             std::vector<TextFragment> textFragments;
 
             size_t length(void) const;
@@ -60,6 +62,9 @@ namespace draw
               * existing text for the TextBox. Note that text fragments are not rendered until
               * after TextBox::setText() is called. */
             void addTextFragment(std::string _text, Colour _colour);
+
+            /** Add a newline after the currently pushed text fragments. */
+            void addNewline(void);
 
             /** Reset the font texture. Since different fonts have different widths, we also
               * need to re-set the text. */

--- a/tiny/draw/textbox.h
+++ b/tiny/draw/textbox.h
@@ -79,6 +79,9 @@ namespace draw
             /** Reserve enough space such that the text can be rendered fully. */
             Renderable * reserve(Renderable * &currentRenderable);
 
+            /** Clear the contents (i.e. all text fragments) of the TextBox. */
+            void clear(void);
+
             /** Set this Text to appear to the top-right of the location
               * specified by screen coordinates (_x,_y), where both coordinates
               * can vary from -1 to +1. */


### PR DESCRIPTION
A number of minor improvements are made here. Firstly, I allow making
new lines to allow paragraph or list structures to be rendered as a
single TextBox object. Secondly, I deleted two lines causing unnecessary
print statements. Thirdly, I allowed clearing the TextBox in order to make
it empty - and to enable the user to change its contents with a re-adding
of text fragments.

Finally, I noticed that the word wrapping went wrong when the wrapping
was triggered by a space character, causing text to start away from the
left margin, as a consequence of using the yet-unused character beyond
the space at which wrapping occurs (which is not yet set if the space
itself is causing the wrapping).
