### PR TITLE
Add hide() function for hiding TextBox's text

### DIFF
--- a/tiny/draw/textbox.cpp
+++ b/tiny/draw/textbox.cpp
@@ -83,6 +83,11 @@ void TextBox::setBoxDimensions(const float &_x, const float &_y, const float &_p
     box = vec4(_x,_y,_p,_q);
 }
 
+void TextBox::hide(void)
+{
+    iconHorde->eraseText();
+}
+
 void TextBox::setText(void)
 {
     iconHorde->eraseText();

--- a/tiny/draw/textbox.h
+++ b/tiny/draw/textbox.h
@@ -79,8 +79,13 @@ namespace draw
             /** Reserve enough space such that the text can be rendered fully. */
             Renderable * reserve(Renderable * &currentRenderable);
 
-            /** Clear the contents (i.e. all text fragments) of the TextBox. */
+            /** Clear the contents (i.e. all text fragments) of the TextBox. To only
+              * make the text invisible, use hide(). */
             void clear(void);
+
+            /** Hide the TextBox, making it invisible, without altering the TextBox itself. To show
+              * the TextBox again, use setText(). */
+            void hide(void);
 
             /** Set this Text to appear to the top-right of the location
               * specified by screen coordinates (_x,_y), where both coordinates


### PR DESCRIPTION
It was already possible to clear the TextBox, but not to simply hide it
(by only cleaning up the ScreenIconHorde but leaving the text fragments
unchanged). This commit adds a simple hide function which calls
ScreenIconHorde::erase() to make the text invisible.
