### PR TITLE
Add function for retrieving size of buffers

### DIFF
--- a/tiny/draw/animatedmesh.cpp
+++ b/tiny/draw/animatedmesh.cpp
@@ -73,6 +73,11 @@ AnimatedMesh::~AnimatedMesh()
 
 }
 
+size_t AnimatedMesh::bufferSize(void) const
+{
+	return indices.size()*sizeof(unsigned int) + vertices.size()*sizeof(tiny::mesh::AnimatedMeshVertex);
+}
+
 void AnimatedMesh::setAnimationFrame(const int &a_frame)
 {
     const int newFrame = 3*nrBones*a_frame;

--- a/tiny/draw/animatedmesh.h
+++ b/tiny/draw/animatedmesh.h
@@ -117,6 +117,8 @@ class AnimatedMesh : public Renderable
         
         std::string getVertexShaderCode() const;
         std::string getFragmentShaderCode() const;
+
+		size_t bufferSize(void) const;
         
     protected:
         void render(const ShaderProgram &) const;

--- a/tiny/draw/renderer.cpp
+++ b/tiny/draw/renderer.cpp
@@ -290,8 +290,6 @@ bool Renderer::freeRenderable(const unsigned int &renderableIndex)
         shaderPrograms.erase(k);
     }
 
-    std::cout << "Freed renderable " << renderableIndex << ", there are " << shaderPrograms.size() << " programs and " << renderables.size() << " renderables." << std::endl;
-
     return true;
 }
 

--- a/tiny/draw/staticmesh.cpp
+++ b/tiny/draw/staticmesh.cpp
@@ -57,6 +57,11 @@ StaticMesh::~StaticMesh()
 
 }
 
+size_t StaticMesh::bufferSize(void) const
+{
+	return indices.size()*sizeof(unsigned int) + vertices.size()*sizeof(tiny::mesh::StaticMeshVertex);
+}
+
 std::string StaticMesh::getVertexShaderCode() const
 {
     return

--- a/tiny/draw/staticmesh.h
+++ b/tiny/draw/staticmesh.h
@@ -68,6 +68,8 @@ class StaticMesh : public Renderable
         
         std::string getVertexShaderCode() const;
         std::string getFragmentShaderCode() const;
+
+		size_t bufferSize(void) const;
         
     protected:
         void render(const ShaderProgram &) const;


### PR DESCRIPTION
For StaticMesh and AnimatedMesh there was not any way to determine the
memory they were using for their buffers. I therefore added a function
bufferSize() to each, which shows how much memory is allocated for
storing the buffers.

Separately, I also removed an unnecessary debug statement in the Renderer that logged the freeing of Renderables. This was a relic of an earlier pull request in which freeing of Renderables was added, and it should probably already have been deleted a while ago.
