### PR TITLE
Extend ScreenFillingSquare to allow all square sizes

### DIFF
--- a/tiny/draw/screensquare.cpp
+++ b/tiny/draw/screensquare.cpp
@@ -16,6 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include <algorithm>
 #include <sstream>
+#include <cmath>
 
 #include <tiny/draw/screensquare.h>
 
@@ -39,6 +40,21 @@ ScreenFillingSquareVertexBufferInterpreter::~ScreenFillingSquareVertexBufferInte
     
 }
 
+void ScreenFillingSquareVertexBufferInterpreter::setSquareDimensions(
+        float left, float top, float right, float bottom)
+{
+    left = std::max(std::min(left, 1.0f), -1.0f);
+    right = std::min(std::max(right, -1.0f), 1.0f);
+    top = std::max(std::min(top, 1.0f), -1.0f);
+    bottom = std::min(std::max(bottom, -1.0f), 1.0f);
+    hostData[0] = tiny::vec2(left, top);
+    hostData[1] = tiny::vec2(left, bottom);
+    hostData[2] = tiny::vec2(right, top);
+    hostData[3] = tiny::vec2(right, bottom);
+
+    sendToDevice();
+}
+
 ScreenFillingSquare::ScreenFillingSquare() :
     Renderable()
 {
@@ -48,6 +64,11 @@ ScreenFillingSquare::ScreenFillingSquare() :
 ScreenFillingSquare::~ScreenFillingSquare()
 {
 
+}
+
+void ScreenFillingSquare::setSquareDimensions(float left, float top, float right, float bottom)
+{
+    square.setSquareDimensions(left, top, right, bottom);
 }
 
 std::string ScreenFillingSquare::getVertexShaderCode() const

--- a/tiny/draw/screensquare.h
+++ b/tiny/draw/screensquare.h
@@ -41,6 +41,8 @@ class ScreenFillingSquareVertexBufferInterpreter : public VertexBufferInterprete
     public:
         ScreenFillingSquareVertexBufferInterpreter();
         ~ScreenFillingSquareVertexBufferInterpreter();
+
+        void setSquareDimensions(float left, float top, float right, float bottom);
 };
 
 class ScreenFillingSquare : public Renderable
@@ -50,6 +52,8 @@ class ScreenFillingSquare : public Renderable
         ~ScreenFillingSquare();
         
         std::string getVertexShaderCode() const;
+
+        void setSquareDimensions(float left, float top, float right, float bottom);
         
     protected:
         void render(const ShaderProgram &) const;


### PR DESCRIPTION
The existing ScreenFillingSquare (see /tiny/draw/screensquare.h) has a
VertexBufferInterpreter that can only fill the entire screen, not a part
of it.

This commit adds a function setSquareDimensions() that allows the user
to reset the size of the screen square to some smaller rectangle that
only covers part of the screen.

Sample screenshot of [Chathran Strata](https://github.com/takenu/strata) displaying new partial-filling
square functionality on the top left:
![strata-partial-screen-fill-crop](https://cloud.githubusercontent.com/assets/11860163/17463804/e255e65a-5cce-11e6-8fe1-45c3b8b83205.png)
