### PR TITLE
Let SDL use compatibility profile in OpenGL context

### DIFF
--- a/tiny/os/sdlapplication.cpp
+++ b/tiny/os/sdlapplication.cpp
@@ -26,6 +26,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <AL/al.h>
 #include <AL/alc.h>
 
+#define NO_SDL_GLEXT
+
 #include <SDL.h>
 #include <SDL_image.h>
 #include <SDL_ttf.h>
@@ -79,7 +81,7 @@ SDLApplication::SDLApplication(const int &a_screenWidth,
     }
     
     //Disable deprecated OpenGL functions and request version >= 3.2.
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);

--- a/tiny/os/sdlapplication.cpp
+++ b/tiny/os/sdlapplication.cpp
@@ -26,8 +26,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <AL/al.h>
 #include <AL/alc.h>
 
-#define NO_SDL_GLEXT
-
 #include <SDL.h>
 #include <SDL_image.h>
 #include <SDL_ttf.h>


### PR DESCRIPTION
Running tiny-game-engine's SDLApplication didn't work on my system
(using OpenGL 3.2.0) due to enforcing SDL to use the core OpenGL profile
at 3.2.0.

Why exactly that happens confuses me considerably, but anyways, enabling
SDL to run OpenGL compatibility does solve the problem, and allows my
system to again run certain apparently-non-core-3.2 features (such as
glEnable(GL_PRIMITIVE_RESTART)).

The adjustment is one line only, in setting SDL's OpenGL context
profile.

This fixes #20 (for me at least).
