### PR TITLE
Allow checking renderable index existence

### DIFF
--- a/tiny/draw/renderer.cpp
+++ b/tiny/draw/renderer.cpp
@@ -293,6 +293,11 @@ bool Renderer::freeRenderable(const unsigned int &renderableIndex)
     return true;
 }
 
+bool Renderer::renderableIndexExists(const unsigned int &renderableIndex) const
+{
+    return (renderables.count(renderableIndex) > 0);
+}
+
 void Renderer::addRenderTarget(const std::string &name)
 {
     if (std::find(renderTargetNames.begin(), renderTargetNames.end(), name) != renderTargetNames.end())

--- a/tiny/draw/renderer.h
+++ b/tiny/draw/renderer.h
@@ -143,6 +143,7 @@ class Renderer
         void clearTargets() const;
         void render() const;
         
+        bool renderableIndexExists(const unsigned int &) const;
     protected:
         void addRenderTarget(const std::string &name);
         

--- a/tiny/draw/worldrenderer.cpp
+++ b/tiny/draw/worldrenderer.cpp
@@ -77,6 +77,16 @@ void WorldRenderer::freeScreenRenderable(const unsigned int &renderableIndex)
     screenToColourRenderer.freeRenderable(renderableIndex);
 }
 
+bool WorldRenderer::worldRenderableIndexExists(const unsigned int &renderableIndex) const
+{
+    return worldToScreenRenderer.renderableIndexExists(renderableIndex);
+}
+
+bool WorldRenderer::screenRenderableIndexExists(const unsigned int &renderableIndex) const
+{
+    return screenToColourRenderer.renderableIndexExists(renderableIndex);
+}
+
 void WorldRenderer::clearTargets() const
 {
     worldToScreenRenderer.clearTargets();

--- a/tiny/draw/worldrenderer.h
+++ b/tiny/draw/worldrenderer.h
@@ -47,6 +47,9 @@ class WorldRenderer
         void freeWorldRenderable(const unsigned int &);
         void freeScreenRenderable(const unsigned int &);
         
+        bool worldRenderableIndexExists(const unsigned int &) const;
+        bool screenRenderableIndexExists(const unsigned int &) const;
+        
         void clearTargets() const;
         void render() const;
         


### PR DESCRIPTION
Renderable indices (in the form of unsigned int's) must be unique for
freeing to be possible. Currently, the only way to 'test' uniqueness of
an index is to create inside a try-catch block and handle the exception
that is thrown on passing a renderable index that already exists.

In this commit, I add functions for checking the presence of a specific
index. This eliminates the risk of exceptions being thrown due to
ignorance regarding which indices are present in the Renderer. While it
can be claimed that the user is responsible for not passing the same
index twice, in complex programs it will undoubtedly be easier to simply
find a free index before trying to add a Renderable to the Renderer,
without having to maintain a duplicate of the Renderer::renderables
map in the client application.